### PR TITLE
Code patches documentation and warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The trackinfo file needs to contain the following data
     replaces = Replaced TrackName
     replaces_music = Replaced Track Music Name
     main_language = Language
+    code_patches = Comma-separated List
 
 
 with author and trackname being the name of the author and the name of the custom track respectively. \
@@ -112,6 +113,10 @@ Italian, etc.
 
 The following languages are supported: \
 English, Japanese, German, Italian, French, Spanish
+
+`code_patches` is an optional comma-separated list of code patches that are required by the custom
+track (e.g. `type-specific-item-boxes`, `sectioned-courses`, or `cpu-only-dead-zones`). This list is
+informative, and will tell the Patcher that certain code patches are required.
 
 # How to create a custom mod zip
 This guide is for when you want to make custom drivers, custom karts or modifications to any of the


### PR DESCRIPTION
The **code_patches** field, a command-separate list of code patch names, has been added to the documentation.

The Patcher (and the Extender) will use the field to determine whether the custom track requires any code patch, potentially throwing a warning if the tool does not support such code patch.

---

Currently, there is no *built-in* support for code patches in the Patcher; a warning will be shown for any custom track that uses any code patch at all.

Example of the warning when Waluigi Stadium Boundless (a modified version that defines the **code_patches** field in the `trackinfo.ini` file) is loaded:

![MKDD Patcher - Code patches warning](https://github.com/RenolY2/mkdd-track-patcher/assets/1853278/16dcd3cc-ea4b-4943-9994-a6665c5db7da)

Support for built-in code patches may be introduced in the future; for now, users still need to apply binary-diff-based code patches as separate mods, as stressed in the warning message.