### PR TITLE
Populate config with default keys in legacy UI.

### DIFF
--- a/patcher-gui.py
+++ b/patcher-gui.py
@@ -7,7 +7,13 @@ from tkinter import filedialog
 from tkinter import messagebox
 
 from src.patcher import *
-from src.configuration import read_config, make_default_config, save_cfg, update_config
+from src.configuration import (
+    read_config,
+    make_default_config,
+    populate_default_config,
+    save_cfg,
+    update_config,
+)
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="> %(message)s")
 log = logging.getLogger(__name__)
@@ -141,6 +147,7 @@ class Application(tk.Frame):
 
         try:
             self.configuration = read_config()
+            populate_default_config(self.configuration)
             log.info("Config file loaded")
             update_config(self.configuration)
         except FileNotFoundError as e:

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -18,13 +18,7 @@ def read_config():
 def make_default_config():
     cfg = configparser.ConfigParser()
 
-    cfg["default paths"] = {
-        "iso": "",
-        "mods": ""
-    }
-    cfg["options"] = {
-        "folder_mode": False
-    }
+    populate_default_config(cfg)
 
     with open(CONFIG_NAME, "w") as f:
         cfg.write(f)
@@ -39,6 +33,19 @@ def update_config(cfg):
         }
 
         save_cfg(cfg)
+
+
+def populate_default_config(cfg):
+    if 'default paths' not in cfg:
+        cfg["default paths"] = {
+            "iso": "",
+            "mods": "",
+        }
+
+    if 'options' not in cfg:
+        cfg["options"] = {
+            "folder_mode": False,
+        }
 
 
 def save_cfg(cfg):


### PR DESCRIPTION
When the config file is initialized by the CustomTkinter-based UI, and then the legacy, Tkinter-based UI is used, an exception was raised, as the config was missing specific keys:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/tkinter/__init__.py", line 1921, in __call__
    return self.func(*args)
  File "/w/mkdd-track-patcher/patcher-gui.py", line 99, in open_file
    initialdir = self.config["default paths"]["mods"]
  File "/usr/lib/python3.10/configparser.py", line 1258, in __getitem__
    raise KeyError(key)
KeyError: 'mods'
```

Those keys are now populated on startup, if they do not yet exist.

Note that this issue was only relevant when the legacy UI was used after the config had been initialized from the new UI.