### PR TITLE
Add description to `FileNotFoundError` exception messages.

### DIFF
--- a/src/rarc.py
+++ b/src/rarc.py
@@ -343,7 +343,7 @@ class Directory(object):
             elif name in self.files:
                 return self.files[name]
             else:
-                raise FileNotFoundError(path)
+                raise FileNotFoundError(f'Unable to find "{path}" in ARC file')
         elif name in self.files:
             raise RuntimeError("File", name, "is a directory in path", path, "which should not happen!")
         else:
@@ -545,7 +545,7 @@ class Archive(object):
 
         if rest is None or rest.strip() == "":
             if dirname != self.root.name:
-                raise FileNotFoundError(path)
+                raise FileNotFoundError(f'Unable to find "{path}" in ARC file')
             else:
                 return self.root
         else:


### PR DESCRIPTION
Without a description, the handler that extracts the exception message from the exception only sees a sole filepath.

This is what users were presented with before this change:

![MKDD Patcher - FileNotFoundError exception message](https://github.com/RenolY2/mkdd-track-patcher/assets/1853278/be98a5b9-7ba3-4c00-a849-af8c821faf03)