### PR TITLE
Enforce forward slashes in audio waves processing.

### DIFF
--- a/src/patcher.py
+++ b/src/patcher.py
@@ -608,7 +608,7 @@ def patch(
                     continue
 
                 corrected_filepath = os.path.join(root_dir, f'{wave_index}.wav')
-                used_audio_waves[corrected_filepath].append(mod)
+                used_audio_waves[corrected_filepath.replace(os.sep, '/')].append(mod)
 
                 data = patcher.zip_open(f'audio_waves/{filepath}').read()
 


### PR DESCRIPTION
The `GCM` in the `gcm` Python module outputs paths using `/` as path separator regardless of the filesystem. On the other hand, the keys in `used_audio_waves` were constructed using `os.path.join()`, which would use `os.sep`, resulting in the use of `\` on NTSF systems.

This was leading to an exception that manifested when the audio waves in a mod did not match the expected sample rate or duration, which causes a warning:

```
Traceback (most recent call last):
  File "...\mkdd_patcher.py", line 290, in patch
    patcher.patch(input_iso, output_iso, custom_tracks, message_callback, prompt_callback,
  File "...\src\patcher.py", line 881, in patch
    mod_name = os.path.basename(used_audio_waves[filepath][-1])
IndexError: list index out of range
```

(Ironically, the error was produced while trying to report the warning.)