### PR TITLE
README: Add more context to the `audio_waves` directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,13 @@ as follows:
 
 ```
 .
-└── audio_waves
-    ├── SelectVoice
-    ├── Voice
-    └── CommendationVoice
+├── audio_waves
+│   ├── SelectVoice
+│   ├── Voice
+│   └── CommendationVoice
+├── files
+│   └── ...
+└── modinfo.ini
 ```
 
 The files in these directories are `.wav` audio files (16-bit mono audio at various sample rates),
@@ -178,10 +181,13 @@ audio waves would be provided:
 
 ```
 .
-└── audio_waves
-    └── SelectVoice
-        ├── 35.wav     # Pre-selection voice: when the character is first selected
-        └── 36.wav     # Selection voice: when player confirms the character pair
+├── audio_waves
+│   └── SelectVoice
+│       ├── 35.wav     # Pre-selection voice: when the character is first selected
+│       └── 36.wav     # Selection voice: when player confirms the character pair
+├── files
+│   └── ...
+└── modinfo.ini
 ```
 
 ## Selection Voices


### PR DESCRIPTION
It was noted that modders could wrongly insert the `audio_waves` directory inside the `files` directory, instead of keeping it in a top-level directory.

The `files` directory is now shown in the example directory structure that is included in the README file.