### PR TITLE
Add support for companion cheat codes files in mods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,36 @@ Sounds that do not correspond to any character:
 > Modders can listen to the retail `.wav` files to acquire a sense of the audio clips that are going
 > to be replaced (duration, audio content, sample rate, etc.).
 
+# Baking Cheat Codes
+
+Mods can include a companion cheat codes file that contains Action Replay / Gecko codes. The file
+must be placed next to the `modinfo.ini` or `trackinfo.ini` file. Depending on the region, the name
+of the file is:
+
+- `cheatcodes_US.ini`
+- `cheatcodes_PAL.ini`
+- `cheatcodes_JP.ini`
+- `cheatcodes_US_DEBUG.ini`
+
+Normally, mods should provide a cheat codes file for each region, so that the mod exhibits the same
+behavior regardless of the input ISO that the user chooses.
+
+Cheat codes will be baked directly into the DOL file; no code handler will be installed. The
+supported code types are:
+
+- `00______ ________` 8-bit write and fill (only single-byte writes)
+- `02______ ________` 16-bit write and fill
+- `04______ ________` 32-bit write
+- `06______ ________` String write
+
+Cheat codes must be provided in their unencrypted form; the encrypted `____-____-_____` form that is
+often used in Action Replay codes is not supported. Lines that do no start with an alphanumeric
+character will be ignored (e.g. lines starting with `$`, `*`, or  `[...]`).
+
+Conflicts can be produced when two or more mods feature cheat codes that happen to write different
+values to the same memory address. When a conflict is detected during the build, a warning is
+issued, prompting the user to either abort or continue the build process.
+
 # Switching tracks to different track slots
 Sometimes you might have two custom tracks that go over the same track slot. In that case, without
 manual intervention, it's not possible to play both at once. In that case check the trackinfo.ini inside

--- a/src/dolreader.py
+++ b/src/dolreader.py
@@ -87,7 +87,10 @@ class DolFile(object):
         
         self._curraddr = self._text[0][1]
         self.seek(self._curraddr)
-    
+
+    def get_raw_data(self) -> BytesIO:
+        return self._rawdata
+
     @property
     def sections(self):
         for i in self._text:
@@ -96,7 +99,13 @@ class DolFile(object):
             yield i 
         
         return
-    
+
+    def is_address_resolvable(self, gc_addr: int) -> bool:
+        for _offset, address, size in self.sections:
+            if address <= gc_addr < address + size:
+                return True
+        return False
+
     # Internal function for resolving a gc address 
     def _resolve_address(self, gc_addr):
         for offset, address, size in self.sections:
@@ -143,7 +152,10 @@ class DolFile(object):
         write_uint32(f, self.bsssize)
         
         f.seek(curr)
-    
+
+    def can_write_or_read_in_current_section(self, size: int) -> bool:
+        return self._curraddr + size <= self._current_end
+
     # Unsupported: Reading an entire dol file 
     # Assumption: A read should not go beyond the current section 
     def read(self, size):


### PR DESCRIPTION
Mods can now include a companion cheat codes file that contains Action Replay / Gecko codes. The file must be placed next to the `modinfo.ini` or `trackinfo.ini` file. Depending on the region, the name of the file is:

- `cheatcodes_US.ini`
- `cheatcodes_PAL.ini`
- `cheatcodes_JP.ini`
- `cheatcodes_US_DEBUG.ini`

Cheat codes will be baked directly into the DOL file; no code handler will be installed. The supported code types are:

- `00______ ________` 8-bit write and fill (only single-byte writes)
- `02______ ________` 16-bit write and fill
- `04______ ________` 32-bit write
- `06______ ________` String write