### PR TITLE
Support for folder mode with custom mods.

### DIFF
--- a/src/zip_helper.py
+++ b/src/zip_helper.py
@@ -121,14 +121,17 @@ class ZipToIsoPatcher(object):
         return fp
     
     def get_file_changes(self, startpath):
-        startpath = Path(self.root+startpath)
+        if self._is_folder:
+            startpath = Path(os.path.basename(self.zip.filepath) + os.path.sep + startpath)
+        else:
+            startpath = Path(self.root + startpath)
         arcs = {}
         files = []
 
         for filepath in self.zip.namelist():
             filepath_path = Path(filepath)
             if self._is_folder:
-                if self.zip.is_dir(filepath):
+                if self.zip.is_dir(os.path.join(os.path.dirname(self.zip.filepath), filepath)):
                     continue
             else:
                 zippath = zipfile.Path(self.zip, filepath)


### PR DESCRIPTION
Previously, only custom courses could be used in folder mode (i.e. with the path to the custom course pointing to an *unzipped* directory).

The `get_file_changes()` function that is used to traverse the files in `files/` (and, more recently, also in `audio_waves/`) was not handling mods in folder mode properly.