### PR TITLE
Locate WSY files in a more robust way to support NTSC-J.

### DIFF
--- a/src/patcher.py
+++ b/src/patcher.py
@@ -128,11 +128,14 @@ def patch_audio_waves(audio_waves_tmp_dir: str, baac_filepath: str, iso) -> dict
         1: 'Voice',
         2: 'CommendationVoice',
     }
+    BAA_NAMES_START_INDEX = 1 if '1.wsy' in os.listdir(parent_dirpath) else 2
     BAA_NAMES = {
-        2: 'NintendoLogo',
-        3: 'SoundEffects',
-        4: 'BGMSamples',
+        BAA_NAMES_START_INDEX + 0: 'NintendoLogo',
+        BAA_NAMES_START_INDEX + 1: 'SoundEffects',
+        BAA_NAMES_START_INDEX + 2: 'BGMSamples',
     }
+    first_baa_filepath = os.path.join(parent_dirpath, f'{next(iter(BAA_NAMES.keys()))}.wsy')
+    assert os.path.isfile(first_baa_filepath)
     ALL_BAA_NAMES = tuple(NESTED_BAA_NAMES.values()) + tuple(BAA_NAMES.values())
 
     retail_copy_dirpath = os.path.join(tempfile.gettempdir(), 'mkdd-retail-audio-waves')


### PR DESCRIPTION
With the introduction of the custom sound effects support (see #26), the WSY files in the `GCKart.baa` file are now extracted and processed.

It was wrongly assumed that the file indexes for the WSY files were:

- `2.wsy`
- `3.wsy`
- `4.wsy`

However, in the NTSC-J region, the filenames are:

- `1.wsy`
- `2.wsy`
- `3.wsy`

An exception was raised when the unnested WSY files were processed:

```
Traceback (most recent call last):
  File "/w/mkdd-track-patcher/mkdd_patcher.py", line 290, in patch
    patcher.patch(input_iso, output_iso, custom_tracks, message_callback, prompt_callback,
  File "/w/mkdd-track-patcher/src/patcher.py", line 1114, in patch
    audio_errors_by_file = patch_audio_waves(audio_waves_tmp_dir, baac_filepath, iso)
  File "/w/mkdd-track-patcher/src/patcher.py", line 193, in patch_audio_waves
    assert os.path.isfile(wsys_filepath)
AssertionError
```