### PR TITLE
Support for cheat codes that write to memory areas not defined in the DOL header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ Conflicts can be produced when two or more mods feature cheat codes that happen 
 values to the same memory address. When a conflict is detected during the build, a warning is
 issued, prompting the user to either abort or continue the build process.
 
+> [!NOTE]
+> Cheat codes are often developed with the assumption that a code handler will be installed in the
+> game. Since MKDD Patcher does not install a code handler, it is possible some cheat codes do not
+> function as expected. The only way to verify whether a certain cheat code is supported is to test
+> it.
+
 # Switching tracks to different track slots
 Sometimes you might have two custom tracks that go over the same track slot. In that case, without
 manual intervention, it's not possible to play both at once. In that case check the trackinfo.ini inside

--- a/src/dolreader.py
+++ b/src/dolreader.py
@@ -1,5 +1,6 @@
-import struct 
 import logging
+import operator
+import struct
 from io import BytesIO, RawIOBase
 
 log = logging.getLogger(__name__)
@@ -155,6 +156,89 @@ class DolFile(object):
 
     def can_write_or_read_in_current_section(self, size: int) -> bool:
         return self._curraddr + size <= self._current_end
+
+    def check_section_and_grow_if_needed(self, gc_addr: int, gc_size: int) -> tuple[bool, str]:
+        assert gc_size > 0
+        gc_end_addr = gc_addr + gc_size
+
+        sections = tuple(self.sections)
+
+        # Check whether the section already exists and can fit the size.
+        for _offset, address, size in sections:
+            end_address = address + size
+            if address <= gc_addr < end_address and address < gc_end_addr <= end_address:
+                return True, ''
+
+        sorted_sections = sorted(sections, key=operator.itemgetter(1))
+
+        # Find the section that precedes the input address; this will be the section that needs to
+        # grow.
+        for section in reversed(sorted_sections):
+            offset, address, size = section
+            if address <= gc_addr:
+                break
+        else:
+            return False, f'Unable to find suitable section for 0x{gc_addr:08X}.'
+
+        # Check how much it needs to grow.
+        end_address = address + size
+        delta = gc_end_addr - end_address
+
+        # Verify that the new section size would not overlap with the next section.
+        if section is not sorted_sections[-1]:
+            next_section = sorted_sections[sorted_sections.index(section) + 1]
+            if end_address + delta > next_section[1]:
+                return (
+                    False,
+                    f'Unable to grow section at 0x{address:08X} to fit {gc_size} bytes at '
+                    f'0x{gc_addr:08X} (overlapping with next section at 0x{next_section[1]:08X}).',
+                )
+
+        # Advance offsets in sections that follow the target section and update section size in the
+        # target section.
+        new_text = []
+        for section in self._text:
+            if section[0] > offset:
+                new_text.append((section[0] + delta, section[1], section[2]))
+            elif section[1] == address:
+                new_text.append((section[0], section[1], section[2] + delta))
+            else:
+                new_text.append(section)
+        self._text.clear()
+        self._text.extend(new_text)
+        new_data = []
+        for section in self._data:
+            if section[0] > offset:
+                new_data.append((section[0] + delta, section[1], section[2]))
+            elif section[1] == address:
+                new_data.append((section[0], section[1], section[2] + delta))
+            else:
+                new_data.append(section)
+        self._data.clear()
+        self._data.extend(new_data)
+
+        # All good to update the DOL header.
+        self._adjust_header()
+
+        # And finally insert zeros at the back of the section.
+        rawdata = bytes(self._rawdata.getbuffer())
+        rawdata = rawdata[:offset + size] + b'\x00' * delta + rawdata[offset + size:]
+        self._rawdata = BytesIO(rawdata)
+
+        # Incapacitate `memset()` in `__init_data()` (same address in all known builds), as
+        # otherwise it is likely that the data that is written to memory outside of the DOL sections
+        # will be zeroed, making this work futile.
+        self.seek(0x800033D8)
+        self.write(struct.pack('>I', 0x60000000))
+        # NOTE: Tests have shown that this should be safe: all the data that the `memset()` calls
+        # would clear, except for one single 32-bit word written by `OSSetErrorHandler()`, is
+        # already null. The word that `OSSetErrorHandler()` writes holds the address to the previous
+        # error handler, which is returned to the caller in r3 (to allow the caller to restore the
+        # previous handler, presumably). However, the next call to `OSSetErrorHandler()` does not
+        # consume the return value (in fact, the value is discarded in absolutely all calls, even in
+        # the debug build), therefore not zeroing the value is not an issue.
+
+        return True, ''
 
     # Unsupported: Reading an entire dol file 
     # Assumption: A read should not go beyond the current section 

--- a/src/patcher.py
+++ b/src/patcher.py
@@ -424,10 +424,6 @@ def parse_cheat_codes(text: str,
                         'The implementation of this code type differs between the Action Replay '
                         'and Gecko code handler: only single-byte writes are supported.')
 
-            if not dol.is_address_resolvable(address):
-                return (f'Unsupported code at line #{line_number}:\n\n    {line}\n\n'
-                        f'Address 0x{address:08X} cannot be resolved.')
-
             size = 0
             if data_size == 0:  # 8-bit write & fill
                 size = 1  # We only support single-byte writes
@@ -438,10 +434,9 @@ def parse_cheat_codes(text: str,
             elif data_size == 3:  # String write
                 size = value
 
-            dol.seek(address)
-            if not dol.can_write_or_read_in_current_section(size):
-                return (f'Unsupported code at line #{line_number}:\n\n    {line}\n\n'
-                        f'Write of {size} bytes at 0x{address:08X} goes beyond the section limit.')
+            section_available, error_message = dol.check_section_and_grow_if_needed(address, size)
+            if not section_available:
+                return f'Unsupported code at line #{line_number}:\n\n    {line}\n\n{error_message}'
 
             cheat_codes.append((
                 line_number,

--- a/src/patcher.py
+++ b/src/patcher.py
@@ -428,6 +428,7 @@ def parse_cheat_codes(text: str,
                 return (f'Unsupported code at line #{line_number}:\n\n    {line}\n\n'
                         f'Address 0x{address:08X} cannot be resolved.')
 
+            size = 0
             if data_size == 0:  # 8-bit write & fill
                 size = 1  # We only support single-byte writes
             elif data_size == 1:  # 16-bit write & fill
@@ -484,6 +485,8 @@ def bake_cheat_codes(cheat_codes_filename: str, cheat_codes_by_mod: dict[str, li
 
             assert (code_subtype, code_type) == (0, 0)
             assert data_size in (0, 1, 2, 3)
+
+            payload = bytes()
 
             if data_size == 0:  # 8-bit write & fill
                 # NOTE: Action Replay and Gecko treat the multiplier differently: the former uses


### PR DESCRIPTION
Not all cheat codes write to memory sections that are well defined in the DOL header. This is fine when a code handler is available, as the code handler will apply the cheat code after the game's OS has been initialized.

However, in MKDD Patcher, since no code handler will be installed, all cheat codes need to be baked into a proper section. In the absence of such section, MKDD Patcher will try to find the section that precedes the address where the data needs to be written and resize it.

The following mod can be used for testing this functionality:

[`EverythingUnlocked.zip`](https://github.com/user-attachments/files/18565846/EverythingUnlocked.zip)

The cheat code in the mod (which writes to unmanaged memory areas) will unlock all cups, courses, characters, karts, and game modes.